### PR TITLE
Use crates.io version of rust_lsp and adapt example to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 log = "0.3"
 env_logger = "0.3"
-rust_lsp = { version = "0.5.0" , git = "https://github.com/RustDT/RustLSP" }
+rust_lsp = "0.6"
 
 [lib]
 name = "mock_ls_lib"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@
 
 #[macro_use] extern crate log;
 extern crate env_logger;
-extern crate example_ls;
 extern crate rust_lsp;
 
+mod mock_ls;
 
 use std::env;
 use std::io;
@@ -37,7 +37,7 @@ fn main() {
 		// Use stdin/stdout
 		
 		let stdin = std::io::stdin();
-		example_ls::run_lsp_server(&mut stdin.lock(), move || std::io::stdout());
+		mock_ls::run_lsp_server(&mut stdin.lock(), move || std::io::stdout());
 	} else {
 		let mut args = env::args();
 		args.next();
@@ -87,7 +87,7 @@ fn handle_client(stream: TcpStream) {
 	
 	let mut input = io::BufReader::new(stream.try_clone().expect("Failed to clone stream"));
 	
-	example_ls::run_lsp_server(&mut input, || {
+	mock_ls::run_lsp_server(&mut input, || {
 		stream
 	});
 }

--- a/src/mock_ls.rs
+++ b/src/mock_ls.rs
@@ -11,17 +11,16 @@
 
 extern crate rust_lsp;
 
-
 use rust_lsp::ls_types::*;
-use rust_lsp::lsp_server::*;
+use rust_lsp::lsp::{LanguageServerHandling, LSCompletable, LSPEndpoint};
 use rust_lsp::jsonrpc::method_types::MethodError;
-use rust_lsp::jsonrpc::EndpointOutput;
 use rust_lsp::jsonrpc::MethodCompletable;
+use rust_lsp::jsonrpc::Endpoint;
 
 use std::io;
 
 pub struct DummyLanguageServer {
-	endpoint_output : EndpointOutput,
+	endpoint_output : Endpoint
 }
 
 pub fn run_lsp_server<OUT, OUT_P>(input: &mut io::BufRead, out_stream_provider: OUT_P)
@@ -33,7 +32,7 @@ where
 	
 	let ls = DummyLanguageServer{ endpoint_output : endpoint_output.clone() };
 	
-	LSPEndpoint::run_server_from_input(ls, input, endpoint_output);
+	LSPEndpoint::run_server_from_input(input, endpoint_output, ls);
 }
 
 /**
@@ -49,7 +48,7 @@ impl DummyLanguageServer {
 	
 }
 
-impl LanguageServer for DummyLanguageServer {
+impl LanguageServerHandling for DummyLanguageServer {
 	
 	fn initialize(&mut self, _: InitializeParams, completable: MethodCompletable<InitializeResult, InitializeError>) {
 		let capabilities = ServerCapabilities::default();
@@ -114,6 +113,12 @@ impl LanguageServer for DummyLanguageServer {
 		completable.complete(Err(Self::error_not_available(())))
 	}
 	fn rename(&mut self, _: RenameParams, completable: LSCompletable<WorkspaceEdit>) {
+		completable.complete(Err(Self::error_not_available(())))
+	}
+	fn document_link(&mut self, params: DocumentLinkParams, completable: LSCompletable<Vec<DocumentLink>>) {
+		completable.complete(Err(Self::error_not_available(())))
+	}
+	fn document_link_resolve(&mut self, params: DocumentLink, completable: LSCompletable<DocumentLink>) {
 		completable.complete(Err(Self::error_not_available(())))
 	}
 }


### PR DESCRIPTION
The version of rust_lsp in Cargo.toml is now 0.6 and is pulled
from crates.io when building the project.
The changes in the other files fix various issues with the new
version.

	modified:   Cargo.toml
	modified:   src/main.rs
	modified:   src/mock_ls.rs